### PR TITLE
Add psmisc support; fix rsession environment issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,21 @@ FROM leader.telekube.local:5000/ae-editor:5.3.1-22.g6cafcc9c5
 COPY . /aesrc/rstudio/
 RUN set -ex \
     && cd /aesrc/rstudio \
+    && if [ ! $(rpm -qa psmisc) ]; then \
+          if [ ! -f psmisc-22.20-16.el7.x86_64.rpm ]; then \
+             curl -O https://rpmfind.net/linux/centos/7.7.1908/os/x86_64/Packages/psmisc-22.20-16.el7.x86_64.rpm; \
+          fi \
+          rpm -i psmisc-22.20-16.el7.x86_64.rpm; \
+       fi \
     && if [ ! -f rstudio-server-rhel-1.2.1335-x86_64.rpm ]; then \
           curl -O https://download2.rstudio.org/server/centos6/x86_64/rstudio-server-rhel-1.2.1335-x86_64.rpm; \
        fi \
     && rpm -i rstudio-server-rhel-1.2.1335-x86_64.rpm \
-    && rm -rf rstudio-server-rhel-1.2.1335-x86_64.rpm \
+    && rm *.rpm \
     && cp Rprofile /opt/continuum/.Rprofile \
     && if [ ! -f /opt/continuum/scripts/start_user.sh ]; then \
            cp startup.sh build_condarc.py run_tool.py /opt/continuum/scripts/; \
        fi \
     && cp rsession.sh start_rstudio.sh /opt/continuum/scripts/ \
     && chmod +x /opt/continuum/scripts/*.sh \
-    && chown anaconda:anaconda /opt/continuum/scripts/*.sh
+    && chown anaconda:anaconda /opt/continuum/.Rprofile /opt/continuum/scripts/*.sh

--- a/Rprofile
+++ b/Rprofile
@@ -21,9 +21,9 @@
       counter = 0
       cat('Waiting...')
       while (!file.exists(fpath)) {
-          Sys.sleep(0.1)
+          Sys.sleep(0.2)
           counter = counter + 1
-          if (counter == 30) {
+          if (counter == 15) {
               counter = 0
               cat('.')
               flush.console()
@@ -35,6 +35,11 @@
         message('Restarting R...')
         .rs.api.restartSession()
       }
+    } else if (Sys.getenv('CONDA_PROJECT_ERR') == 'yes') {
+      message('ERROR: an unexpected error prevented the startup script')
+      message('from determining the desired conda environment. This is')
+      message('typically caused by corruption in anaconda-project.yml.')
+      message('Consult the file /opt/continuum/prepare.log for details.')
     } else if (current_env != desired_env) {
       message('Requested conda environment: ', desired_env)
       message('ERROR: The project preparation stage is complete, but the')

--- a/rsession.sh
+++ b/rsession.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "+-- START: AE5 R Session Manager ---"
+
 # This environment must have an R installation
 CONDA_FALLBACK_ENV=anaconda50_r
 
@@ -12,63 +14,82 @@ OCLB=$OCA/envs/lab_launch/bin
 # RStudio strips out most environment variables before calling
 # rsession, for some reason. We want at least the CONDA environment
 # to be visible to R, so start_rstudio.sh puts them here
-echo "- Reading conda environment variables"
 while read -r line; do
-    declare -x $line
+    eval "export $line"
 done < ~/.Renviron
-OLD_PFX=$CONDA_PREFIX
-echo "- Current environment: $CONDA_DEFAULT_ENV ($CONDA_PREFIX)"
-echo "- Current path: $PATH"
+OLD_PREFIX=$CONDA_PREFIX
+OLD_DESIRED=$CONDA_DESIRED_ENV
+# If the previous conda environment has R we can use it as the fallback.
+# That way if someone changes the environment to one without R, at least
+# it will fall back to the one they were using previously.
+[ -x $CONDA_PREFIX/lib/R/lib/libR.so ] && CONDA_FALLBACK_ENV=$CONDA_DEFAULT_ENV
+
+# Our log display in Ops Center strips out leading spaces. Adding the non-space
+# prefix allows us to better read the results
+echo "| Current environment: $CONDA_DEFAULT_ENV"
+echo "|   CONDA_PREFIX: $CONDA_PREFIX"
+echo "|   R_HOME: $R_HOME"
+echo "|   PATH: $PATH"
+echo "|   LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
 
 # Now determine the environment dictacted by the project, as
 # given by the first environment in anaconda-project.yml. If
 # this file is broken, we revert to the fallback environment
-CONDA_DESIRED_ENV=$(cd $OC/project && $OCLB/anaconda-project list-env-specs </dev/null | grep -A1 ^= | tail -1)
+export CONDA_DESIRED_ENV=$(cd $OC/project && $OCLB/anaconda-project list-env-specs </dev/null | grep -A1 ^= | tail -1)
 if [ "$CONDA_DESIRED_ENV" ]; then
-    echo "- Target environment: $CONDA_DESIRED_ENV"
+    echo "| Target environment: $CONDA_DESIRED_ENV"
 else
-    echo "- Missing or corrupt anaconda-project.yml"
-    CONDA_DESIRED_ENV=$CONDA_DEFAULT_ENV
+    echo "| Missing or corrupt anaconda-project.yml"
+    export CONDA_DESIRED_ENV=$CONDA_FALLBACK_ENV
+    export CONDA_PROJECT_ERR=yes
 fi
 
 # Switch environments if necessary. However, if the new environment
 # does not have R, we need to switch to the fallback.
 if [ "$CONDA_DESIRED_ENV" == "$CONDA_DEFAULT_ENV" ]; then
-    echo "- No environment change needed"
+    echo "| No environment change needed"
 
 elif source $OCAB/activate $CONDA_DESIRED_ENV; then
-    echo "- New environment: $CONDA_DEFAULT_ENV ($CONDA_PREFIX)"
-    echo "- New path: $PATH"
+    echo "| Activation of environment succeeded"
 
 else
-    echo "- Activation of environment $CONDA_DESIRED_ENV failed"
+    echo "| ERROR: Activation of environment failed"
 fi
 
-if ! which R; then
-    echo "- R not found; activating fallback environment"
+if [ ! -x $CONDA_PREFIX/lib/R/lib/libR.so ]; then
+    echo "| ERROR: R not found; activating fallback environment"
     source $OCAB/activate $CONDA_FALLBACK_ENV
-    echo "- New environment: $CONDA_DEFAULT_ENV ($CONDA_PREFIX)"
-    echo "- New path: $PATH"
 fi
 
-# Update the R_HOME-based environment variables
-if [ "$OLD_PFX" != "$CONDA_PREFIX" ]; then
-    echo "- pointing environment variables to the new environment"
-    vars=$(env | sed -nE "/^CONDA/!s@$OLD_PFX/@$CONDA_PREFIX/@p")
+if [ "$R_HOME" != "$CONDA_PREFIX/lib/R" ]; then
+    echo "| Pointing R_HOME, etc. to the correct environment"
+    R_PREFIX=$(dirname $(dirname $R_HOME))
+    vars=$(env | sed -nE '/^CONDA/!'"s@$R_PREFIX/@$CONDA_PREFIX/@gp")
     while read -r line; do
         declare -x $line
     done <<< "$vars"
-
-    echo "- Writing new conda environment variables"
-    env | grep ^CONDA > ~/.Renviron
-    echo PATH=$PATH >> ~/.Renviron
+else
+    echo "| R_HOME is correct"
 fi
 
-# Add CONDA_DESIRED_ENV to ~/.Renviron so .Rprofile sees it
-echo CONDA_DESIRED_ENV=$CONDA_DESIRED_ENV >> ~/.Renviron
+if [ "$CONDA_PREFIX@$CONDA_DESIRED_ENV" != "$OLD_PREFIX@$OLD_DESIRED" ]; then
+    echo "| Writing conda environment variables to .Renviron"
+    env | sed -nE 's@^(CONDA[^=]*)=(.*)@\1="\2"@p' > ~/.Renviron
+else
+    echo "| Conda environment variables in .Renviron are correct"
+fi
 
-# We need $CONDA_PREFIX/lib in LD_LIBRARY_PATH
-# $CONDA_PREFIX/lib/R/lib is already in there
+# We need to add $CONDA_PREFIX/lib in LD_LIBRARY_PATH for rsession
+# $CONDA_PREFIX/lib/R/lib is already in there by virtue of activation
+echo "| Adding CONDA_PREFIX/lib to LD_LIBRARY_PATH"
 export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
-echo "- Executing rsession with arguments: $@"
+
+echo "| Final environment: $CONDA_DEFAULT_ENV"
+echo "|   CONDA_PREFIX: $CONDA_PREFIX"
+echo "|   R_HOME: $R_HOME"
+echo "|   PATH: $PATH"
+echo "|   LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+
+echo "| Executing rsession with arguments: $@"
+echo "+-- END: AE5 R Session Manager ---"
 exec /usr/lib/rstudio-server/bin/rsession "$@"

--- a/start_rstudio.sh
+++ b/start_rstudio.sh
@@ -4,8 +4,7 @@ rm -rf ~/.rstudio
 killall rsession 2>/dev/null
 
 source /opt/continuum/anaconda/bin/activate anaconda50_r
-env | grep ^CONDA > ~/.Renviron
-echo PATH=$PATH >> ~/.Renviron
+env | sed -nE 's@^(CONDA[^=]*)=(.*)@\1="\2"@p' > ~/.Renviron
 echo session-default-working-dir=/opt/continuum/project > ~/.rsession.conf
 echo session-rprofile-on-resume-default=1 >> ~/.rsession.conf
 


### PR DESCRIPTION
@edennuriel I have incorporated your psmisc fix into this PR along with some other necessary improvements I uncovered during testing.

The most significant problem was this: when `rsession.sh` is run, its initial value of `R_HOME` is determined by the environment activated in `start_rstudio.sh`, which is nominally `anaconda50_r`. This starting value persists through _multiple_ session restarts. That means that if the project's selected conda environment is _not_ `rsession.sh`, then it needs to reset it every single time. This is _different_ than the conda environment, which will hold its previous value between restarts.

So we're now doing more careful checking of whether or not `R_HOME` needs to be reset. Interestingly, RStudio doesn't actually use the `R` startup script itself. Rather, `/usr/lib/rstudio-server/bin/rsession` dynamically loads the version of `libR.so` that is contained in the conda environment. So `R_HOME` and `LD_LIBRARY_PATH` are more important to get right at startup.

Other fixes described in inline comments.

cc: @edennuriel — note I will cherry pick your other changes into here too, in different PRs.