### PR TITLE
541 conda bin and custom envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ the new image will be minimal.
    could also edit the Dockerfile by hand if you wish.
    ```
    sed -i "s@^FROM .*@FROM $WORKSPACE@" Dockerfile
-   # --network=host is only required on ae541 and only if there is no local file avilable during build. The docker bridge network was removed
+   # When using curl to download the rstudio binary and minimizing image size, --network=host is required for internet access as the docker bridge network was removed in 541
    docker build --network=host --build-arg WORKSPACE=$WORKSPACE -t $WORKSPACE-rstudio .
    docker push $WORKSPACE-rstudio
    ```

--- a/install_rstudio.sh
+++ b/install_rstudio.sh
@@ -16,26 +16,12 @@ fi
 rpm -i rstudio-server-rhel-1.2.5033-x86_64.rpm
 rm *.rpm
 
-
-# 5.3.x back compatibility fixes
-if [ ! -f /opt/continuum/scripts/start_user.sh ]; then
-    cp startup.sh build_condarc.py run_tool.py /opt/continuum/scripts/
-fi
-
-# Rstudio scripts
-cp Rprofile /opt/continuum/.Rprofile
-cp rsession.sh start_rstudio.sh /opt/continuum/scripts/
-
-# Fix ownership and permissions
-chmod +x /opt/continuum/scripts/*.sh
-chown anaconda:anaconda /opt/continuum/.Rprofile /opt/continuum/scripts/*.sh
-
 # for some reason on AE541 ae-editor, conda is not in path and build fail - using full path... 
 conda=conda
 [[ command -v $conda ]] || conda='/opt/continuum/anaconda/condabin/conda'
 [[ -f $conda ]] || exit 1
 
-# Create the custom environments
+# Create the custom environments - only if environment files are present 
 envs=$(ls *.txt 2>/dev/null)
 for envtxt in $envs; do
     envname=${envtxt%.txt}
@@ -50,4 +36,18 @@ if [ $envname ]; then
     rm -rf /opt/continuum/anaconda/pkgs/*
     conda clean --all
 fi
+
+
+# 5.3.x back compatibility fixes
+if [ ! -f /opt/continuum/scripts/start_user.sh ]; then
+    cp startup.sh build_condarc.py run_tool.py /opt/continuum/scripts/
+fi
+
+# Rstudio scripts
+cp Rprofile /opt/continuum/.Rprofile
+cp rsession.sh start_rstudio.sh /opt/continuum/scripts/
+
+# Fix ownership and permissions
+chmod +x /opt/continuum/scripts/*.sh
+chown anaconda:anaconda /opt/continuum/.Rprofile /opt/continuum/scripts/*.sh
 


### PR DESCRIPTION

When testing on 541 I found the following...
- conda is not found in the image (not in path)
- docker build fail without any custom envs
