### PR TITLE
Add .dockerignore, .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+screenshot.png
+README.md
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+condarc
+*.txt
+


### PR DESCRIPTION
No need to copy the screenshot and readme into the Docker container. And we do want to make sure that any environment text files and condarc files that we create for testing are not accidentally committed.