### PR TITLE
Remove java as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Adding RStudio support to AE5.5.1+
 
-> **NOTE**: there is an [operating-system issue](https://bugzilla.redhat.com/show_bug.cgi?id=1909037) 
+> **NOTE**: there is an
+> [operating-system issue](https://bugzilla.redhat.com/show_bug.cgi?id=1909037) 
 > that prevents some R environments from working with RStudio.
 > This has been corrected in AE5.5.2. For AE5.5.1, there is a
 > simple workaround: add the conda package `openldap=2.4` to
@@ -176,14 +177,14 @@ each file is renamed after downloading, as described here.
 1. Download the CentOS 8 RPM:
 
    ```
-   https://download2.rstudio.org/server/centos8/x86_64/rstudio-server-rhel-2021.09.0-351-x86_64.rpm
+   https://download2.rstudio.org/server/rhel8/x86_64/rstudio-server-rhel-2022.07.1-554-x86_64.rpm
    ```
 
 2. Rename this file `rs-centos8.rpm`.
 3. Download the CentOS 7 RPM:
 
    ```
-   https://download2.rstudio.org/server/centos7/x86_64/rstudio-server-rhel-2021.09.0-351-x86_64.rpm
+   https://download2.rstudio.org/server/centos7/x86_64/rstudio-server-rhel-2022.07.1-554-x86_64.rpm
    ```
 
 4. Rename this file `rs-centos7.rpm`.

--- a/install_java.sh
+++ b/install_java.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+echo "+--------------------+"
+echo "| AE5 Java Installer |"
+echo "+--------------------+"
+
+if [ ! -z "$CONDA_PREFIX" ]; then
+    source deactivate 2>/dev/null
+fi
+java_loc=$(which java 2>/dev/null)
+if [ "$java_loc" == "/usr/bin/java" ]; then
+    echo 'ERROR: this script is intended for AE 5.6 or later.'
+    exit -1
+elif [[ "$java_loc" == /tools/java/* ]]; then
+    echo 'ERROR: java is already installed. Remove /tools/java to reinstall.'
+    exit -1
+elif [[ -z "$TOOL_PROJECT_URL" || -z "$TOOL_HOST" || -z "$TOOL_OWNER" ]]; then
+    echo 'ERROR: this script must be run within an AE5 session.'
+    exit -1
+elif [ ! -d /tools ]; then
+    echo 'ERROR: this script requires the managed persistence /tools volume.'
+    exit -1
+elif [ -e /tools/java ]; then
+    if [ ! -d /tools/java ]; then
+        echo 'ERROR: /tools/java is not a directory.'
+        exit -1
+    elif [ ! -w /tools/java ]; then
+        echo 'ERROR: /tools/java is not writable.'
+        exit -1
+    elif [ ! -z "$(ls -A /tools/java)" ]; then
+        echo 'ERROR: /tools/java is not empty.'
+        exit -1
+    fi
+elif ! mkdir -p /tools/java; then
+    echo 'ERROR: the /tools/java directory could not be created.'
+    exit -1
+fi
+
+if [ ! -z "$1" ]; then
+    java_fn=$1
+    if [ ! -f "$1" ]; then
+        echo "ERROR: java tarball not found: $1"
+        exit -1
+    fi
+fi
+if [ -z "$java_fn" ]; then
+    java_url=${JAVA_URL:-https://download.oracle.com/java/18/archive/jdk-18_linux-x64_bin.tar.gz}
+    echo "Downloading: $java_url"
+    java_fn=$(basename $java_url)
+    if ! curl -L --output $java_fn $java_url; then
+        echo "ERROR: could not download Java. To proceed manually:"
+        echo "1. https://www.oracle.com/java/technologies/downloads/"
+        echo "2. Download the JDK version you prefer, making sure to select the"
+        echo "   Linux x64 Compressed Archive"
+        echo "3. Upload that file to this project."
+        echo "4. Re-run this script, supplying the name of the file as an argument."
+        exit -1
+    fi
+fi
+if ! tar tvf "$java_fn" >/dev/null; then
+    echo "ERROR: tarball could not be verified: $java_fn"
+    exit -1
+fi
+
+echo "Unpacking java..."
+tar xf "$java_fn" -C /tools/java 
+
+echo "+-----------------------+"
+echo "Java installation is complete."
+echo "Stop and restart your session to verify AE5 detects it."
+echo "+-----------------------+"

--- a/install_rstudio.sh
+++ b/install_rstudio.sh
@@ -22,22 +22,6 @@ elif [ $RSTUDIO_PREFIX != /usr/lib/rstudio-server ]; then
     exit -1
 fi
 
-if [ ! -z "$CONDA_PREFIX" ]; then
-    source deactivate 2>/dev/null
-fi
-java_loc=$(which java 2>/dev/null)
-if [ -z "$java_loc" ]; then
-    echo "ERROR: RStudio requires a centrally installed Java package"
-    echo "for operation. The latest version of Java can be obtained"
-    echo "from the Linux x64 link on this page:"
-    echo "  https://www.java.com/en/download/manual.jsp"
-    echo "Unpack this tarball manually into the directory /tools/java,"
-    echo "then stop and restart this session to proceed."
-    exit -1
-else
-    echo "- Found java: $java_loc"
-fi
-
 RSTUDIO_PARENT=$(dirname $RSTUDIO_PREFIX)
 if [[ -d $RSTUDIO_PREFIX || $RSTUDIO_PREFIX != /tools/rstudio ]]; then
     if [ ! -d $RSTUDIO_PREFIX ]; then
@@ -129,3 +113,13 @@ echo "RStudio installation is complete."
 echo "Once you have verified the installation, feel free to"
 echo "shut down this session and delete the project."
 echo "+-----------------------+"
+[ -z "$CONDA_PREFIX" ] || source deactivate
+java_loc=$(which java 2>/dev/null)
+if [ -z "$java_loc" ]; then
+    echo "WARNING: Many R packages make use of Java, and it seems"
+    echo "not to be present on this installation of AE5. To make"
+    echo "Java available to all AE5 users, run install_java.sh, or"
+    echo "manually download a JDK Linux x64 archive and unpack its"
+    echo "contents into the directory /tools/java."
+echo "+-----------------------+"
+fi


### PR DESCRIPTION
Java is actually not required to run RStudio, even though it is used by a reasonably large number of R packages.