### PR TITLE
bump to 2022.12.0-353

### DIFF
--- a/download_rstudio.sh
+++ b/download_rstudio.sh
@@ -4,7 +4,7 @@ echo "+------------------------+"
 echo "| AE5 RStudio Downloader |"
 echo "+------------------------+"
 
-[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2022.07.1-554
+[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2022.12.0-353
 echo "- Target version: ${RSTUDIO_VERSION}"
 
 if [[ ! -z "$TOOL_PROJECT_URL" && -d data ]]; then

--- a/skeleton/.config/rstudio/rstudio-prefs.json
+++ b/skeleton/.config/rstudio/rstudio-prefs.json
@@ -1,0 +1,3 @@
+{
+    "posix_terminal_shell": "bash"
+}


### PR DESCRIPTION
Bump to the latest version of RStudio.
During my testing I observed that the terminal windows weren't coming up. I went into the RStudio preferences, went to the terminal section, made no changes, and hit "Apply". That created the rstudio-prefs.json file below. All was well after that. So I've added it to the skeleton.