### PR TITLE
Major rewrite / rsession simplification

### DIFF
--- a/Rprofile
+++ b/Rprofile
@@ -3,10 +3,11 @@
     message(paste(strwrap(paste(..., collapse=' ')), collapse='\n'))
   }
   wait_for_prepare_log <- function(newSession) {
-    readRenviron('/opt/continuum/.Renviron')
+    if (file.exists('/tmp/.rstudio_environment'))
+        readRenviron('/tmp/.rstudio_environment')
     current_env = Sys.getenv('CONDA_DEFAULT_ENV')
     desired_env = Sys.getenv('CONDA_DESIRED_ENV')
-    fpath = '/opt/continuum/prepare.log'
+    fpath = '~/prepare.log'
     cat('Active conda environment:', current_env, '\n')
     if (!file.exists(fpath)) {
       if (current_env == desired_env) {

--- a/configure_env.sh
+++ b/configure_env.sh
@@ -1,0 +1,66 @@
+TOOL_HOME=$(dirname "${BASH_SOURCE[0]}")
+
+path_echo() {
+    echo "$@" | sed \
+        -e "s@$CONDA_PREFIX@\$CONDA_PREFIX@g" \
+        -e "s@$CONDA_ROOT@\$CONDA_ROOT@g" \
+        -e "s@$JAVA_HOME@\$JAVA_HOME@g" \
+        -e "s@/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin@<system>@"
+}
+
+if [ -f /tmp/.rstudio_environment ]; then
+    # RStudio strips out most environment variables before calling
+    # rsession for some reason, which means users do not see them
+    # either. This restores them for our purposes.
+    while read -r line; do
+        export ${line%%=*}="${line#*=}"
+    done < /tmp/.rstudio_environment
+fi
+
+env_info=$($CONDA_PYTHON_EXE $TOOL_HOME/default_env.py $PWD)
+if [ "$env_info" = "$CONDA_DESIRED_ENV $CONDA_DEFAULT_ENV $RSTUDIO_DEFAULT_R_VERSION" ]; then
+    echo "| CONDA_PREFIX: $CONDA_PREFIX"
+    # return when sourced; exit when run standalone for testing
+    return 2>/dev/null || exit
+fi
+
+CONDA_DESIRED_ENV=$(echo $env_info | cut -d ' ' -f 1)
+active_env=$(echo $env_info | cut -d ' ' -f 2)
+active_ver=$(echo $env_info | cut -d ' ' -f 3)
+echo "| Current environment: $CONDA_DEFAULT_ENV"
+echo "| Project environment: $CONDA_DESIRED_ENV"
+echo "| Startup environment: $active_env ($active_ver)"
+
+OLD_PREFIX=$CONDA_PREFIX
+if [ "$CONDA_DEFAULT_ENV" != "$active_env" ]; then
+    echo "| Activating: $active_env"
+    source $CONDA_ROOT/bin/activate $active_env
+fi
+
+if [[ "$OLD_PREFIX" != "$CONDA_PREFIX" && -f "$OLD_PREFIX/bin/R" ]]; then
+    # Make sure all old references to the old environment are gone
+    PATH=$(echo $PATH | sed "s@$OLD_PREFIX/bin:@@g")
+    LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | sed "s@$OLD_PREFIX/lib[^:]*:@@g")
+    # This is intended to rewrite RStudio-generated variables
+    vars=$(env | sed -nE "s@$OLD_PREFIX/@$CONDA_PREFIX/@gp")
+    while read -r line; do
+        export ${line%%=*}="${line#*=}"
+    done <<< "$vars"
+fi
+
+echo "| CONDA_DESIRED_ENV: $CONDA_DESIRED_ENV"
+echo "| CONDA_DEFAULT_ENV: $CONDA_DEFAULT_ENV"
+echo "| CONDA_PREFIX: $CONDA_PREFIX"
+echo "| CONDA_ROOT: $CONDA_ROOT"
+[ -n "$JAVA_HOME" ] && echo "| JAVA_HOME: $JAVA_HOME"
+path_echo "| PATH: $PATH"
+export CONDA_DEFAULT_ENV CONDA_DESIRED_ENV CONDA_PREFIX PATH LD_LIBRARY_PATH
+
+# Ensure rsession sees all of the currently available environment variables
+export RSTUDIO_DEFAULT_R_VERSION=$active_ver
+export RMARKDOWN_MATHJAX_PATH=$TOOL_HOME/resources/mathjax-27
+export RS_RPOSTBACK_PATH=$TOOL_HOME/bin/rpostback
+export R_PROFILE=$TOOL_HOME/Rprofile
+
+# Save the current environment for the next potential rsession start
+env > /tmp/.rstudio_environment

--- a/default_env.py
+++ b/default_env.py
@@ -1,15 +1,56 @@
+import os
 import sys
 import ruamel_yaml
-home_dir = '/opt/continuum/project' if len(sys.argv) < 2 else sys.argv[1]
+from glob import glob
+from os.path import dirname, basename, join
+
+PROJECT_DIR = sys.argv[1]
+ENVS_DIRS = [
+    '/opt/continuum/.conda/envs',
+    '/opt/continuum/envs',
+    '/opt/continuum/anaconda/envs'
+]
+
+def _intif(x):
+    try:
+        return int(x)
+    except:
+        return 0
+
+r_envs = []
+r_versions = {}
+all_envs = set()
+for ebase in ENVS_DIRS:
+    g_envs = []
+    for emeta in glob(join(ebase, '*', 'conda-meta')):
+        epath = dirname(emeta)
+        ename = basename(epath)
+        if ename in all_envs:
+            ename = epath
+        all_envs.add(ename)
+        for pkg in glob(join(emeta, 'r-base-*.json')):
+            r_versions[ename] = basename(pkg).split('-', 3)[2]
+            ver = tuple(map(_intif, r_versions[ename].split('.')))
+            g_envs.append((ver, ename))
+    r_envs.extend(v for k, v in sorted(g_envs, reverse=True))
+
+results = []
 try:
-    with open(home_dir.rstrip('/') + '/anaconda-project.yml', 'r') as fp:
+    with open(join(PROJECT_DIR, 'anaconda-project.yml'), 'r') as fp:
         envs = ruamel_yaml.safe_load(fp).get('env_specs')
-    result = []
     if not envs or 'default' in envs:
-        result.append('default')
-    result.extend(e for e in envs if e != 'default')
-    print(' '.join(result))
+        results.append('default')
+    results.extend(e for e in envs if e != 'default')
 except Exception as exc:
-    print('ERROR: {}'.format(exc), file=sys.stderr)
-    print('Could not determine the conda environment; please check anaconda-project.yml.', file=sys.stderr)
-    print('@ERROR@')
+    results.append('@ERROR@')
+desired_env = results[0]
+results = [r for r in results if r in r_envs]
+if results:
+    active_env = results[0]
+elif os.environ.get('CONDA_DEFAULT_ENV') in r_envs:
+    active_env = os.environ['CONDA_DEFAULT_ENV']
+elif r_envs:
+    active_env = next(iter(r_envs))
+else:
+    active_env = desired_env
+print(desired_env, active_env, r_versions[active_env])

--- a/download_rstudio.sh
+++ b/download_rstudio.sh
@@ -7,15 +7,25 @@ echo "+------------------------+"
 [ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2023.12.0-369
 echo "- Target version: ${RSTUDIO_VERSION}"
 
-if [[ ! -z "$TOOL_PROJECT_URL" && -d data ]]; then
+if [[ -n "$TOOL_PROJECT_URL" && -d data ]]; then
    echo "- Downloading into the data directory"
    fdir=data/
 fi
 
-# We actually need two RPM packages: the CentOS 8 version is the version we
-# use in full, but we need to extract a single binary (rsession) from the
-# CentOS 7 version to offer compatibility with older versions of R.
-for os_ver in 9 8 7; do
+if [ -z "$TOOL_PROJECT_URL" ]; then
+    echo "- Downloading both versions for airgap"
+    needed="8 9"
+elif grep -q 'release 9' /etc/redhat-release; then
+    echo "- Downloading RHEL9 version only"
+    needed=9
+else
+    echo "- Downloading RHEL8 version only"
+    needed=8
+fi
+
+# We download all three RPM versions here so we can ensure what we need
+# for every supported version of AE5 and R.
+for os_ver in $needed; do
     what_os="RHEL${os_ver}/CentOS${os_ver}"
     fname=${fdir}rs-centos${os_ver}.rpm
     echo "- Downloading $what_os RPM file to $fname"

--- a/rsession.conf
+++ b/rsession.conf
@@ -1,8 +1,0 @@
-session-default-working-dir=/opt/continuum/project
-session-rprofile-on-resume-default=1
-r-resources-path=/tools/rstudio/resources
-r-core-source=/tools/rstudio/R
-r-modules-source=/tools/rstudio/R/modules
-external-quarto-path=/tools/rstudio/bin/quarto
-external-pandoc-path=/tools/rstudio/bin/tools
-external-node-path=/tools/rstudio/bin/nodejs

--- a/rsession.sh
+++ b/rsession.sh
@@ -1,147 +1,65 @@
 #!/bin/bash
 
-echo "+-- START: AE5 R Session Manager ---"
-
 TOOL_HOME=$(dirname "${BASH_SOURCE[0]}")
-echo "| RStudio home: $TOOL_HOME"
-echo "| User home: $HOME"
 
-# This must be the name of an environment guaranteed to have a
-# valid R installation, so that in case of user error RStudio
-# knows where to find at least one valid R environment.
-CONDA_FALLBACK_ENV=anaconda50_r
+# When activation is slow, RStudio will assume the launched session has
+# died and attempt to launch another. RStudio doesn't care, however, if
+# the new process or the old actually finishes and grabs the socket. So
+# this establishes a simple process queue. If for some reason an earlier
+# process fails, the next one on the list will attempt.
+pidfile=$RS_SESSION_TMP_DIR/rsession.sh.pid
+echo $$>>$pidfile
+first=yes
+while read -r pid; do
+    [ $pid == $$ ] && break
+    first=no
+    echo "| New pid $$ waiting"
+    while ps -p $pid &>/dev/null; do
+        sleep 3
+        pid2="$(cat $HOME/.local/share/rstudio/sources/session-*/lock_file 2>/dev/null || :)"
+        [ -n "$pid2" ] && exit 0
+    done
+done <$pidfile
 
-OCA=$HOME/anaconda
-OCP=$HOME/project
-OCAB=$OCA/bin
-OCCB=$OCA/condabin
+[ $first = yes ] && echo "+-- START: AE5 R Session Manager ---"
+echo "| Lock obtained for pid $$"
 
-# RStudio strips out most environment variables before calling
-# rsession, for some reason. We want at least the CONDA environment
-# to be visible to R, so start_rstudio.sh puts them here
-while read -r line; do
-    eval "export $line"
-done < ~/.Renviron
+# This which R environment to start with. Ideally, the project
+# environment is ready in which case it can be selected. But if it is
+# not, we must select an existing environment, because RStudio requires
+# one to exist when the it starts
+source $TOOL_HOME/configure_env.sh
 
-# If the previous conda environment has R we can use it as the fallback.
-# That way if someone changes the environment to one without R, at least
-# it will fall back to the one they were using previously.
-[ -x $CONDA_PREFIX/lib/R/lib/libR.so ] && CONDA_FALLBACK_ENV=$CONDA_DEFAULT_ENV
-
-# Our log display in Ops Center strips out leading spaces. Adding the non-space
-# prefix allows us to better read the results
-echo "| Current environment: $CONDA_DEFAULT_ENV"
-echo "|   CONDA_PREFIX: $CONDA_PREFIX"
-echo "|   R_HOME: $R_HOME"
-echo "|   PATH: $PATH"
-echo "|   LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
-
-# Now determine the environment dictacted by the project, as
-# given by the first environment in anaconda-project.yml. If
-# this file is broken, we revert to the fallback environment
-CONDA_DESIRED_ENV=
-all_envs=$($OCAB/python $TOOL_HOME/default_env.py $OCP)
-echo "| Project environments: $all_envs"
-for env in $all_envs $CONDA_FALLBACK_ENV; do
-    [ "$CONDA_DESIRED_ENV" ] || CONDA_DESIRED_ENV=$env
-    if [ "$env" = "@ERROR@" ]; then
-        echo "| Missing or corrupt anaconda-project.yml"
-        env=$CONDA_FALLBACK_ENV
-    fi
-    echo "| Attempting to use env: $env"
-    if [ "$env" = "$CONDA_DEFAULT_ENV" ]; then
-        echo "|  No activation needed"
-    else
-        # In theory we should only need source activate here. But for some reason
-        # the activate/deactivate scripts are failing and LDFLAGS is not changed
-        # when it should be. This matters below because LDFLAGS may contain paths
-        # that point to the old environment.
-        source $OCCB/deactivate 2>/dev/null
-        unset LDFLAGS
-        if source $OCCB/activate $env; then
-            echo "|  Activation of environment succeeded"
-        else
-            echo "|  Activation of environment FAILED"
-            env="@ERROR@"
-        fi
-    fi
-    if [[ "$env" != "@ERROR@" && -x "$CONDA_PREFIX/lib/R/lib/libR.so" ]]; then
-        echo "|  Presence of R library verified"
-        break
-    else
-        echo "|  R library NOT PRESENT in this environment"
-    fi
-done
-export CONDA_DESIRED_ENV
-
-# A number of the environment variables still point to the R environment that
-# was visible to RStudio when it was first run. Modify those to point to the
-# new environment so that the R process will be properly configured
-if [ "$R_HOME" != "$CONDA_PREFIX/lib/R" ]; then
-    echo "| Pointing R_HOME, etc. to the correct environment"
-    R_PREFIX=$(dirname $(dirname $R_HOME))
-    vars=$(env | sed -nE 's@^([^=]=)(.*)@\1"\2"@;/^CONDA/!'"s@$R_PREFIX/@$CONDA_PREFIX/@gp")
-    while read -r line; do
-        eval "export $line"
-    done <<< "$vars"
-else
-    echo "| R_HOME is correct"
-fi
-
-# The installed version of RStudio uses OpenSSL 1.1, while our versions of R 3.5 use
-# OpenSSL 1.0. Unfortunately RStudio doesn't realize this and dynamically links our R
-# to their rsession binary in an incompatible way. To fix this we assume an OpenSSL 1.0
-# version of rsession is available with the name "rsession10" and point it at our
-# conda environment version of OpenSSL
-sslver=$(ls -l $CONDA_PREFIX/lib/libssl.so | awk '{print $NF;}')
-echo "| SSL library detected: $sslver"
-if [ -f $CONDA_PREFIX/bin/rsession ]; then
-  echo "| Using environmnent-hosted rsession"
-  RSESSION=$CONDA_PREFIX/bin/rsession
-elif [[ "$sslver" == libssl.so.3* ]]; then
-  echo "| Using OpenSSL 3.0 version of rsession"
-  RSESSION=rsession30
-elif [[ "$sslver" == libssl.so.1.1* ]]; then
-  echo "| Using OpenSSL 1.1 version of rsession"
-  [ -f /lib64/libssl.so.1.1* ] && nativessl=yes
-  RSESSION=rsession11
-elif [[ "$sslver" == libssl.so.1.0* ]]; then
-  echo "| Using OpenSSL 1.0 version of rsession"
-  ln -s $CONDA_PREFIX/lib/libssl.so $CONDA_PREFIX/lib/libssl.so.10 2>/dev/null || :
-  ln -s $CONDA_PREFIX/lib/libcrypto.so $CONDA_PREFIX/lib/libcrypto.so.10 2>/dev/null || :
-  RSESSION=rsession10
-else
-  echo "| Defaulting to OpenSSL 3.0 version of rsession"
-  RSESSION=rsession30
+pid="$(cat $HOME/.local/share/rstudio/sources/session-*/lock_file 2>/dev/null || :)"
+if [ -n "$pid" ] && ps -p $pid &>/dev/null; then
+    echo "| Session already running; exiting."
+    echo "+-- END: AE5 R Session Manager ---"
+    exit 0
 fi
 
 # Make sure $CONDA_PREFIX/lib and $CONDA_PREFIX/lib/R/lib are in LD_LIBRARY_PATH
-# RStudio actually adds $CONDA_PREFIX/lib/R/lib for us, but we overwrite that
-# when we read in .Renviron above, so we're putting it back here again.
-echo "| Adding CONDA_PREFIX libraries to LD_LIBRARY_PATH"
-__tmp=$(echo $LD_LIBRARY_PATH: | sed "s@$CONDA_PREFIX/lib\(/R/lib\)\?:@@g")
-LD_LIBRARY_PATH=$CONDA_PREFIX/lib/R/lib:$CONDA_PREFIX/lib:${__tmp%:}
-# work around: /lib64/libldap.so.2: undefined symbol: EVP_md2, version OPENSSL_3.0.0
-[ "$RSESSION" = rsession30 ] && LD_LIBRARY_PATH=/lib64:$LD_LIBRARY_PATH
-[[ $RSESSION = /* ]] || RSESSION=$TOOL_HOME/bin/$RSESSION
-export LD_LIBRARY_PATH
+# RStudio actually adds $CONDA_PREFIX/lib/R/lib for us, but configure_env.sh
+# might overwrite that, so we're putting it back here again.
+LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | sed -E "s@$CONDA_PREFIX/lib[^:]*(:|$)@@g")
+[ -n "$JAVA_HOME" ] && LD_LIBRARY_PATH="$JAVA_HOME/lib/server:$LD_LIBRARY_PATH"
+LD_LIBRARY_PATH=$CONDA_PREFIX/lib/R/lib:$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
+if ! grep -aq "GLIBCXX_3.4.29" $CONDA_PREFIX/lib/libstdc++.so; then
+    echo "| Older libstdc++ detected; using correction"
+    LD_LIBRARY_PATH=/lib64:$LD_LIBRARY_PATH
+fi
+path_echo "| LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
 
-echo "| Final environment: $CONDA_DEFAULT_ENV"
-echo "|   CONDA_PREFIX: $CONDA_PREFIX"
-echo "|   R_HOME: $R_HOME"
-echo "|   PATH: $PATH"
-echo "|   LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
-
-# RStudio strips out much of the environment before launching the R console
-# and shell terminals. We need the CONDA variables if we want to use conda on
-# the command line. The PATH variable is not always preserved either. By putting
-# these variables in .Renviron we ensure they will be restored. We also need
-# NSS_WRAPPER_* and LD_PRELOAD passed through so that RStudio terminals can
-# see the nss_wrapper-supplied username.
-echo "| Writing environment variables to .Renviron"
-export R_PROFILE=$TOOL_HOME/Rprofile
-env | grep -vE "^ANACONDA_(SESSION_|ENTERPRISE_(AP|NGINX|REDIS|POSTGRES)_)" | sed -nE 's@^([^=]*)=(.*)@\1="\2"@p' > ~/.Renviron
-
-echo "| Running: $RSESSION $@"
+args=($TOOL_HOME/bin/rsession \
+      --session-default-working-dir /opt/continuum/project \
+      --session-rprofile-on-resume-default 1 \
+      --r-resources-path $TOOL_HOME/resources \
+      --r-core-source $TOOL_HOME/R \
+      --r-modules-source /tools/rstudio/R/modules \
+      --external-quarto-path /tools/rstudio/bin/quarto \
+      --external-pandoc-path /tools/rstudio/bin/tools \
+      --external-node-path /tools/rstudio/bin/nodejs)
+cmd="${args[@]} $@"
+echo @Running: $cmd@ | fold -s | sed 's/^/  /;s/$/\\/;s/^  @//;s/@\\//;s/^/| /'
 echo "+-- END: AE5 R Session Manager ---"
-exec $RSESSION "$@"
+rm $pidfile
+exec $cmd

--- a/start_rstudio.sh
+++ b/start_rstudio.sh
@@ -1,20 +1,15 @@
 #!/bin/bash
 
+echo "+-- START: AE5 RStudio Startup ---"
 TOOL_HOME=$(dirname "${BASH_SOURCE[0]}")
-echo "RStudio home: $TOOL_HOME"
-echo "User home: $HOME"
 
-# RStudio Server must have R on its path when it launches.
-# It does not need to be the actual environment the project uses; our
-# custom rsession script will switch R_HOME and the PATH accordingly.
-source $HOME/anaconda/bin/activate anaconda50_r
+# Determine which R environment to start with. Ideally, the project
+# environment is ready in which case it can be selected. But if it is
+# not, we must select an existing environment, because RStudio requires
+# one to exist when the it starts
+source $TOOL_HOME/configure_env.sh
 
-# Ensure R sees all of the currently available environment variables
-env | sed -nE 's@^([^=]*)=(.*)@\1="\2"@p' > $HOME/.Renviron
-
-args=($TOOL_HOME/bin/rserver \
-      --rsession-config-file $TOOL_HOME/rsession.conf \
-      --rsession-path $TOOL_HOME/rsession.sh \
+args=($TOOL_HOME/bin/rserver --rsession-path $TOOL_HOME/rsession.sh \
       --auth-none=1 --auth-validate-users=0 --auth-minimum-user-id=1 \
       --server-working-dir=$HOME --server-user=$(id -un))
 
@@ -23,5 +18,7 @@ args=($TOOL_HOME/bin/rserver \
 [[ $TOOL_ADDRESS ]] && args+=(--www-address=$TOOL_ADDRESS)
 [[ $TOOL_IFRAME_HOSTS ]] && args+=(--www-frame-origin=$TOOL_IFRAME_HOSTS)
 
-echo "${args[@]}"
-exec "${args[@]}"
+cmd="${args[@]}"
+echo @Running: $cmd@ | fold -s | sed 's/^/  /;s/$/\\/;s/^  @//;s/@\\//;s/^/| /'
+echo "+-- END: AE5 RStudio Startup ---"
+exec $cmd


### PR DESCRIPTION
For reasons that are not entirely clear, Posit's `rsession` application is now more broadly compatible with multiple versions of R. I've been able to run the RHEL 9 `rsession` against all major Linux versions of conda R from 3.4 onward, with only a small special treatment required for our very old legacy environment `anaconda50_r`. This is likely a combination of upgrades to our low-level conda libraries as well as changes Posit has made. So this now means we have much less adaptation to do to make rsession work with our binaries.

We still need the environment detection capability, however. I've refactored how we do that, though, so that if the environment already exists on start time, the (slow) activation process is done before the session comes up for the first time. This makes RStudio seem to come up more quickly and reliably. In the event that the user changes R environments on the fly, I studied RStudio's session launching behavior closely and managed to make our script more robust to timeouts.

Finally I improved our environment search capability. It looks for R environments in the following priority order:
- named environments in anaconda-project.yml, in listed order
- the previously selected R environment, if one had been selected before
- other environments in the user's persistent storage, from newest R version to oldest
- environments in admin persistent storage (/opt/continuum/envs), from newest R version to oldest
- environments on the docker container (anaconda50_r)

The first environment with an `r-base` package wins.